### PR TITLE
Don't collapse the navbar unless we're on a _really_ small screen

### DIFF
--- a/scripts/templates/base.html
+++ b/scripts/templates/base.html
@@ -7,27 +7,26 @@
 <html class="h-100">
 
 <body class="d-flex flex-column h-100">
-    <nav class="navbar sticky-top navbar-expand-lg navbar-dark bg-dark">
-        <a class="navbar-brand">BotC Scripts</a>
-
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-            <ul class="navbar-nav mr-auto">
-                <li class="nav-item">
-                    <a class="nav-link" href="/">Home</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="/upload">Upload</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="/statistics">Statistics</a>
-                </li>
-            </ul>
-            <ul class="navbar-nav pull-right">
-                <li class="nav-item">
-                    <a class="nav-link" href="https://github.com/AdmiralGT/botc-scripts" target="_blank">GitHub</a>
-                </li>
-            </ul>
-        </div>
+    <nav class="navbar sticky-top navbar-expand-sm navbar-dark bg-dark">
+    <a class="navbar-brand">BotC Scripts</a>
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <ul class="navbar-nav">
+            <li class="nav-item">
+                <a class="nav-link" href="/">Home</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="/upload">Upload</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="/statistics">Statistics</a>
+            </li>
+        </ul>
+        <ul class="navbar-nav ml-auto">
+            <li class="nav-item">
+                <a class="nav-link" href="https://github.com/AdmiralGT/botc-scripts" target="_blank">GitHub</a>
+            </li>
+        </ul>
+    </div>
     </nav>
 
     <main role="main" class="flex-shrink-0">


### PR DESCRIPTION
It turns out, I'd told bootstrap to collapse the navbar if the screen size was reduced below 992px (large). I actually want to keep the navbar in most cases so reduce to small