### PR TITLE
Allow users to update existing scripts without releasing a new version

### DIFF
--- a/scripts/forms.py
+++ b/scripts/forms.py
@@ -81,22 +81,24 @@ class ScriptForm(forms.Form):
             script_name = json_name if json_name else entered_name
 
             script = models.Script.objects.get(name=script_name)
-            new_version = cleaned_data["version"]
-
-            if script.versions.count() == 0:
-                latest_version = "0"
-            else:
-                latest_version = str(script.latest_version().version)
-
-            if Version(new_version) <= Version(latest_version):
-                raise ValidationError(
-                    f"Version {new_version} must be newer than latest version {latest_version}"
-                )
 
             if script.owner and (script.owner != self.user):
                 raise ValidationError(
                     "You are not the owner of this script and cannot upload a new version"
                 )
+
+            if script.latest_version().content != json or cleaned_data.get("pdf", None):
+                new_version = cleaned_data["version"]
+
+                if script.versions.count() == 0:
+                    latest_version = "0"
+                else:
+                    latest_version = str(script.latest_version().version)
+
+                if Version(new_version) <= Version(latest_version):
+                    raise ValidationError(
+                        f"Version {new_version} must be newer than latest version {latest_version}"
+                    )
 
         except models.Script.DoesNotExist:
             pass


### PR DESCRIPTION
I've seen a few instances where an author has attempted to update a script by changing the notes/author/tags and had to release a new version. This should resolve this.