### PR TITLE
Script Pages support multi pages of content

### DIFF
--- a/scripts/templates/script.html
+++ b/scripts/templates/script.html
@@ -60,7 +60,18 @@
     {% endif %}
 </div>
 
-<div class="row p-1" height="720">
+<ul class="nav nav-tabs" id="myTab" role="tablist">
+    <li class="nav-item">
+        <a class="nav-link active" id="home-tab" data-toggle="tab" href="#home" role="tab" aria-controls="home" aria-selected="true">Home</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" id="profile-tab" data-toggle="tab" href="#profile" role="tab" aria-controls="profile" aria-selected="false">Profile</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" id="contact-tab" data-toggle="tab" href="#contact" role="tab" aria-controls="contact" aria-selected="false">Contact</a>
+    </li>
+</ul>
+<div class="tab-pane fade show active row p-1" height="720" id="home" role="tabpanel" aria-labelledby="home-tab">
     {% if script_version.pdf %}
         <div class="col-sm-6">
             <embed src="{{ script_version.pdf.url }}#toolbar=0" type="application/pdf" width="100%" height="720">

--- a/scripts/templates/script.html
+++ b/scripts/templates/script.html
@@ -95,11 +95,11 @@
     {% else %}
         <div class="tab-pane fade show active col-sm-4" id="characters" role="tabpanel" aria-labelledby="characters-tab">
     {% endif %}
-            {% for role in script_version.content %}
-                {% if role.id != "_meta" %}
-                    <li>{{ role.id }}</li>
-                {% endif %}
-            {% endfor %}
+        {% for role in script_version.content %}
+            {% if role.id != "_meta" %}
+                <li>{{ role.id }}</li>
+            {% endif %}
+        {% endfor %}
     </div>
     {% if changes.items|length > 0 %}
     <div class="tab-pane fade col-sm-4" id="history" role="tabpanel" aria-labelledby="history-tab">

--- a/scripts/templates/script.html
+++ b/scripts/templates/script.html
@@ -60,34 +60,49 @@
     {% endif %}
 </div>
 
+{% if script_version.notes or changes.items|length > 0 %}
 <ul class="nav nav-tabs" id="myTab" role="tablist">
+    {% if script_version.notes %}
     <li class="nav-item">
-        <a class="nav-link active" id="home-tab" data-toggle="tab" href="#home" role="tab" aria-controls="home" aria-selected="true">Home</a>
+        <a class="nav-link active" id="notes-tab" data-toggle="tab" href="#notes" role="tab" aria-controls="notes" aria-selected="true">Notes</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" id="profile-tab" data-toggle="tab" href="#profile" role="tab" aria-controls="profile" aria-selected="false">Profile</a>
+        <a class="nav-link" id="characters-tab" data-toggle="tab" href="#characters" role="tab" aria-controls="characters" aria-selected="false">Characters</a>
     </li>
+    {% else %}
     <li class="nav-item">
-        <a class="nav-link" id="contact-tab" data-toggle="tab" href="#contact" role="tab" aria-controls="contact" aria-selected="false">Contact</a>
+        <a class="nav-link active" id="characters-tab" data-toggle="tab" href="#characters" role="tab" aria-controls="characters" aria-selected="false">Characters</a>
     </li>
+    {% endif %}
+    {% if changes.items|length > 0 %}
+    <li class="nav-item">
+        <a class="nav-link" id="history-tab" data-toggle="tab" href="#history" role="tab" aria-controls="history" aria-selected="false">History</a>
+    </li>
+    {% endif %}
 </ul>
-<div class="tab-pane fade show active row p-1" height="720" id="home" role="tabpanel" aria-labelledby="home-tab">
+{% endif %}
+<div class="tab-content row p-1" height="720">
     {% if script_version.pdf %}
         <div class="col-sm-6">
             <embed src="{{ script_version.pdf.url }}#toolbar=0" type="application/pdf" width="100%" height="720">
         </div>
     {% endif %}
-    <div class="flex-shrink-0">
-        {% for role in script_version.content %}
-            {% if role.id != "_meta" %}
-                <li>{{ role.id }}</li>
-            {% endif %}
-        {% endfor %}
-    </div>
-    <div class="col-sm-4">
     {% if script_version.notes %}
-        {{ script_version.notes|markdownify }}
+        <div class="tab-pane fade show active col-sm-4" id="notes" role="tabpanel" aria-labelledby="notes-tab">
+            {{ script_version.notes|markdownify }}
+        </div>
+        <div class="tab-pane fade col-sm-4" id="characters" role="tabpanel" aria-labelledby="characters-tab">
+    {% else %}
+        <div class="tab-pane fade show active col-sm-4" id="characters" role="tabpanel" aria-labelledby="characters-tab">
     {% endif %}
+            {% for role in script_version.content %}
+                {% if role.id != "_meta" %}
+                    <li>{{ role.id }}</li>
+                {% endif %}
+            {% endfor %}
+    </div>
+    {% if changes.items|length > 0 %}
+    <div class="tab-pane fade col-sm-4" id="history" role="tabpanel" aria-labelledby="history-tab">
         {% for version, diffs in changes.items %}
             <h2>{{ diffs.previous_version }} -> {{ version }}</h2>
             <div class="row">
@@ -108,6 +123,7 @@
             </div>
         {% endfor %}
     </div>
+    {% endif %}
 </div>
 
 {% endblock %}


### PR DESCRIPTION
If a script has notes and history then the page can be a little overloaded. This feature splits the content into multiple sub pages that the user can flip between. This will allow more content to be added to script pages such as similar scripts, vod links etc.