### PR TITLE
There can be script objects with no versions

### DIFF
--- a/scripts/views.py
+++ b/scripts/views.py
@@ -258,8 +258,8 @@ class StatisticsView(generic.TemplateView):
             else:
                 raise Http404()
         else:
-            context["total"] = models.Script.objects.count()
             queryset = models.ScriptVersion.objects.filter(latest=True)
+            context["total"] = queryset.count()
 
         character_count = {}
         for type in characters.CharacterType:


### PR DESCRIPTION
Fixes #115

There were some Script objects that had no ScriptVersions and so were counted in the statistics but not in the main table. The Statistics now counts the number of scripts used in generating the statistics.