### PR TITLE
Allow statistics to be filtered on all scripts

### DIFF
--- a/scripts/views.py
+++ b/scripts/views.py
@@ -276,7 +276,10 @@ class StatisticsView(generic.TemplateView):
         stats_character = None
         characters_to_display = 5
 
-        queryset = models.ScriptVersion.objects.filter(latest=True)
+        if "all" in self.request.GET:
+            queryset = models.ScriptVersion.objects.all()
+        else:
+            queryset = models.ScriptVersion.objects.filter(latest=True)
 
         if "character" in kwargs:
             if characters.Character.get(kwargs.get("character")):


### PR DESCRIPTION
Reptiles! v1.1.0 is the actual script version in the database in the World Cup, but it's been superceeded by a version not in the World Cup so for statistics it doesn't show up by default. Allow all scripts to be used for stats to get around this.