### PR TITLE
Lazy Load similar script information

### DIFF
--- a/scripts/templates/script.html
+++ b/scripts/templates/script.html
@@ -34,6 +34,35 @@
         showAndDismissAlert("Link Copied to Clipboard")
     }
 </script>
+<script async>
+
+    function createSimilarScriptEntry(script) {
+        const anchorElement = document.createElement('a');
+        anchorElement.href = `/script/${script.scriptPK}`
+        anchorElement.textContent = script.name;
+
+        const listElement = document.createElement('li');
+        listElement.className = 'list-group-item p-0 border-0'
+        listElement.append(`${script.value}% `, anchorElement)
+
+        return listElement
+    }
+
+    async function showSimilarScripts() {
+        const { full, teensyville } = await (await fetch('/script/{{script.pk}}/{{script_version.version}}/similar')).json()
+
+        const fullElements = full.map(createSimilarScriptEntry)
+        const fullList = document.getElementById('similar-full-list');
+        fullList.textContent = '';
+        fullList.append(...fullElements)
+
+        const teensyvilleElements = teensyville.map(createSimilarScriptEntry);
+        const teensyvilleList = document.getElementById('similar-teensyville-list');
+        teensyvilleList.textContent = '';
+        teensyvilleList.append(...teensyvilleElements)
+    }
+    showSimilarScripts()
+</script>
 
 <div class="row">
     <div class="col-auto">
@@ -253,16 +282,12 @@
     {% endif %}
     <div class="tab-pane fade col-sm-6" id="similarity" role="tabpanel" aria-labelledby="similarity-tab">
         <h3>Full Scripts</h3>
-        <ul class="p-0">
-            {% for script_version, similarness in similarity.Full %}
-                <li class="list-group-item p-0 border-0">{{ similarness }}% <a href="/script/{{script_version.script.pk}}">{{script_version.script.name}}</a></li>
-            {% endfor %}
+        <ul class="p-0" id="similar-full-list">
+        loading...
         </ul>
         <h3>Teensyville</h3>
-        <ul class="p-0">
-            {% for script_version, similarness in similarity.Teensyville %}
-                <li class="list-group-item p-0 border-0">{{ similarness }}% <a href="/script/{{script_version.script.pk}}">{{script_version.script.name}}</a></li>
-            {% endfor %}
+        <ul class="p-0" id="similar-teensyville-list">
+        loading...
         </ul>
     </div>
     <div class="tab-pane fade col-sm-6" id="collection" role="tabpanel" aria-labelledby="collection-tab">
@@ -343,5 +368,6 @@
     </div>
     {% endif %}
 </div>
+
 
 {% endblock %}

--- a/scripts/urls.py
+++ b/scripts/urls.py
@@ -62,6 +62,7 @@ urlpatterns = [
         name="download_all_roles_json",
     ),
     path("script/<int:pk>", views.ScriptView.as_view(), name="script"),
+    path("script/<int:pk>/<str:version>/similar", views.get_similar_scripts, name="similar"),
     path("script/<int:pk>/<str:version>", views.ScriptView.as_view(), name="script"),
     path("script/<int:pk>/<str:version>/vote", views.vote_for_script, name="vote"),
     path(

--- a/scripts/views.py
+++ b/scripts/views.py
@@ -721,12 +721,12 @@ def map_similar_scripts(data):
 
 # Seperate call to calculate similar scripts so we can lazy load it
 def get_similar_scripts(request, pk: int, version: str) -> JsonResponse:
+    if request.method != "GET":
+        raise Http404()
+
     current_script = models.ScriptVersion.objects.filter(
             script=pk, version=version
     )[0]
-
-    context = {}
-    context["script_version"] = current_script
     
     similarity = {}
     similarity[models.ScriptTypes.TEENSYVILLE.value] = {}
@@ -742,7 +742,6 @@ def get_similar_scripts(request, pk: int, version: str) -> JsonResponse:
             script_version.content,
             current_script.script_type == script_version.script_type,
         )
-    context["similarity"] = {}
     teensville_scripts = map(map_similar_scripts, sorted(
         similarity[models.ScriptTypes.TEENSYVILLE].items(),
         key=lambda x: x[1],


### PR DESCRIPTION
In relation to #272

I ran some telemtry locally and noticed the similarity calculation was taking over 300ms out of the total 400ms load time for a script. This pr creates a new api to retrieve similar scripts allowing the main script to be rendered while fetching the data in the background. This has reduced the network request of a script to ~ 25ms locally. 

I am unsure on how this will affect production, but would be good to see :). Similar scripts will still take a couple seconds to load likely, but I don't believe people are rushing to view those straight away. I've added a very simple loading dialog to give some user feedback (tried to add a svg but the way the azure storage was setup made it hard locally)

I dont know much about django so am happy for any feedback. 