### PR TITLE
Provide JSON links that work cross-origin over HTTPS

### DIFF
--- a/scripts/templates/script.html
+++ b/scripts/templates/script.html
@@ -30,7 +30,7 @@
     }    
   
     function CopyLink() {
-        navigator.clipboard.writeText("{{request.scheme}}://{{request.META.HTTP_HOST}}/api/scripts/{{script_version.pk}}/json/")
+        navigator.clipboard.writeText("https://{{request.META.HTTP_HOST}}/api/scripts/{{script_version.pk}}/json/")
         showAndDismissAlert("Link Copied to Clipboard")
     }
 </script>

--- a/scripts/viewsets.py
+++ b/scripts/viewsets.py
@@ -26,7 +26,9 @@ class ScriptViewSet(viewsets.ReadOnlyModelViewSet):
 
     @action(methods=["get"], detail=True)
     def json(self, request, pk=None):
-        return Response(models.ScriptVersion.objects.get(pk=pk).content)
+        response = Response(models.ScriptVersion.objects.get(pk=pk).content)
+        response["Access-Control-Allow-Origin"] = "*"
+        return response
 
 
 class TranslationViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
This will allow the JSON links to work in the official BOTC app and Pocket Grimoire, fixing the issue described in #420 
 
Detailed Changes:

- Always provide link as HTTPS
- Set Access-Control-Allow-Origin header to *
