### PR TITLE
Improve similarity calculation for scripts with very few characters.

### DIFF
--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -1,3 +1,4 @@
 # A list of constants that should be consistent across database/form usage
 MAX_SCRIPT_NAME_LENGTH = 100
 MAX_AUTHOR_NAME_LENGTH = 100
+STANDARD_TEENSYVILLE_CHARACTER_COUNT = 12

--- a/scripts/script_json.py
+++ b/scripts/script_json.py
@@ -1,4 +1,5 @@
 import json as js
+from scripts import constants
 from typing import List
 
 
@@ -113,21 +114,24 @@ def get_json_changes(old_json, new_json):
 
 def get_similarity(json1: List, json2: List, same_type: bool) -> int:
     similarity = 0
-    similarity_max = max(len(json1), len(json2))
-    similarity_min = min(len(json1), len(json2))
-    for id in json1:
+    json1_metadata_count = 0
+    json2_metadata_count = 0
+    for i, id in enumerate(json1):
         if id.get("id", "") == "_meta":
-            similarity_max = min(similarity_max, len(json1) - 1)
-            similarity_min = min(similarity_min, len(json1) - 1)
+            json1_metadata_count += 1
             continue
         for id2 in json2:
-            if id2.get("id", "") == "_meta":
-                similarity_max = min(similarity_max, len(json2) - 1)
-                similarity_min = min(similarity_min, len(json2) - 1)
+            if i == 0 and id2.get("id", "") == "_meta":
+                json2_metadata_count += 1
                 continue
             if id.get("id", "id1") == id2.get("id", "id2"):
                 similarity += 1
                 break
+
+    json1_len = len(json1) - json1_metadata_count
+    json2_len = len(json2) - json2_metadata_count
+    similarity_max = max(json1_len, json2_len)
+    similarity_min = max(min(json1_len, json2_len), constants.STANDARD_TEENSYVILLE_CHARACTER_COUNT)
 
     similarity_comp = similarity_max if same_type else similarity_min
     if similarity_comp == 0:

--- a/tests/input/just_the_drunk.json
+++ b/tests/input/just_the_drunk.json
@@ -1,0 +1,10 @@
+[
+    {
+        "id": "_meta",
+        "name": "Just the Drunk",
+        "author": ""
+    },
+    {
+        "id": "drunk"
+    }
+]

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -86,3 +86,18 @@ def test_differences_both_ways():
     assert reverse == 87
     reverse = get_similarity(v2, v1, False)
     assert reverse == 91
+
+
+def test_large_vs_small_script():
+    with open(os.path.join(current_dir, "input/trouble_brewing.json"), "r") as f:
+        v1 = js.load(f)
+    with open(os.path.join(current_dir, "input/just_the_drunk.json"), "r") as f:
+        v2 = js.load(f)
+    similarity = get_similarity(v1, v2, True)
+    assert similarity == 5
+    similarity = get_similarity(v1, v2, False)
+    assert similarity == 8
+    reverse = get_similarity(v2, v1, True)
+    assert reverse == 5
+    reverse = get_similarity(v2, v1, False)
+    assert reverse == 8


### PR DESCRIPTION
If you visit the [page for Trouble Brewing on botc-scripts](https://botc-scripts.azurewebsites.net/script/133/1.0.0) and navigate to the 'Similar Scripts' tab, you will find a script called ['Bluff's Up, Superstar!'](https://botc-scripts.azurewebsites.net/script/6494) listed as being 100% similar to Trouble Brewing. Viewing the script, you will quickly realise that it is a homebrew script with no similarity to TB at all. The reason it ranks so highly is that the uploaded json file has just one character listed in it: The Drunk. Due to the way the similarity calculation currently works this results in the script scoring a 100% match with TB.

When comparing these two scripts, the original calculation for `similarity_max`
```py
similarity_max = max(len(json1), len(json2))
```
results in a sensible value of 22, i.e. max(22, 2). However, inside the for-loop, the value gets recalculated using this expression
```py
similarity_max = min(similarity_max, len(json2) - 1)
```
which results in a value of 1, i.e. min(22, 1), which I don't think is a sensible value.

The change I have made will ensure `similarity_max` and `similarity_min` have sensible values in all cases.

I have added a test to **tests/test_similarity.py** for the scenario described above. If you were to run this test using the old similarity calculation, the code would expect a value of 100% in all cases rather than 5% and 8%.

Most existing similarities should be unaltered by this change. It will hopefully help to remove some erroneous scripts from the top of the similarity rankings though.