### PR TITLE
Correct typos in navbar.html

### DIFF
--- a/scripts/templates/navbar.html
+++ b/scripts/templates/navbar.html
@@ -52,7 +52,7 @@
         <ul class="navbar-nav ml-auto">
             {% if not user.is_authenticated %}
             <li class="nav-item">
-                <a class="nav-link" href="{% url 'account_login' %}">Login/Signup</a>
+                <a class="nav-link" href="{% url 'account_login' %}">Log In/Sign Up</a>
             </li>
             {% else %}
             <li class="nav-item dropdown">


### PR DESCRIPTION
Correct "Login" and "Signup" to "Log In" and "Sign Up" respectively.

This matches the navbar's "Log Out" button and is also grammatically correct:

- "Log In" is the correct verb phrase (imperative mood). "Login" is a noun referring to the credentials or process of logging in.
- "Sign Up" is the correct verb phrase; "Signup" is a noun and not standard in this context.