### PR TITLE
Fix API performance by removing unused queryset annotations

### DIFF
--- a/scripts/models.py
+++ b/scripts/models.py
@@ -136,6 +136,7 @@ class ScriptVersion(models.Model):
     homebrewiness = models.IntegerField(choices=Homebrewiness.choices, default=Homebrewiness.CLOCKTOWER)
 
     objects = ScriptViewManager()
+    plain_objects = models.Manager()
 
     def __str__(self):
         return f"{self.pk}. {self.script.name} - v{self.version}"

--- a/scripts/serializers.py
+++ b/scripts/serializers.py
@@ -6,7 +6,7 @@ from scripts import models, constants, script_json
 class ScriptSerializer(serializers.ModelSerializer):
     name = serializers.CharField(source="script.name")
     script_id = serializers.IntegerField(source="script.pk", read_only=True)
-    score = serializers.IntegerField(source="votes.count", read_only=True)
+    score = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = models.ScriptVersion

--- a/scripts/viewsets.py
+++ b/scripts/viewsets.py
@@ -40,9 +40,7 @@ class ScriptViewSet(viewsets.ModelViewSet):
     ordering = ["-pk"]
 
     def get_queryset(self):
-        queryset = models.ScriptVersion.plain_objects.annotate(
-            score=Count("script__votes", distinct=True)
-        )
+        queryset = models.ScriptVersion.plain_objects.annotate(score=Count("script__votes", distinct=True))
         latest = self.request.query_params.get("latest")
         if latest:
             queryset = queryset.filter(latest=True)
@@ -227,9 +225,7 @@ class TranslateScriptViewSet(viewsets.ReadOnlyModelViewSet):
     ordering = ["-pk"]
 
     def get_queryset(self):
-        queryset = models.ScriptVersion.plain_objects.annotate(
-            score=Count("script__votes", distinct=True)
-        )
+        queryset = models.ScriptVersion.plain_objects.annotate(score=Count("script__votes", distinct=True))
         latest = self.request.query_params.get("latest")
         if latest:
             queryset = queryset.filter(latest=True)

--- a/scripts/viewsets.py
+++ b/scripts/viewsets.py
@@ -1,3 +1,4 @@
+from django.db.models import Count
 from rest_framework import filters, viewsets
 from rest_framework.authentication import BasicAuthentication
 from rest_framework.permissions import BasePermission, IsAuthenticated
@@ -39,10 +40,12 @@ class ScriptViewSet(viewsets.ModelViewSet):
     ordering = ["-pk"]
 
     def get_queryset(self):
-        queryset = models.ScriptVersion.objects.all()
+        queryset = models.ScriptVersion.plain_objects.annotate(
+            score=Count("script__votes", distinct=True)
+        )
         latest = self.request.query_params.get("latest")
         if latest:
-            queryset = models.ScriptVersion.objects.filter(latest=True)
+            queryset = queryset.filter(latest=True)
         return queryset
 
     @action(methods=["get"], detail=True)
@@ -224,10 +227,12 @@ class TranslateScriptViewSet(viewsets.ReadOnlyModelViewSet):
     ordering = ["-pk"]
 
     def get_queryset(self):
-        queryset = models.ScriptVersion.objects.all()
+        queryset = models.ScriptVersion.plain_objects.annotate(
+            score=Count("script__votes", distinct=True)
+        )
         latest = self.request.query_params.get("latest")
         if latest:
-            queryset = models.ScriptVersion.objects.filter(latest=True)
+            queryset = queryset.filter(latest=True)
         return queryset
 
     def get_object(self, pk: int):


### PR DESCRIPTION
The ScriptViewManager annotates every query with 4 expensive COUNT DISTINCT JOINs (num_tags, score, num_favs, num_comments). These are needed by the web views but are unused by the API, causing slow responses at high page numbers due to offset-based pagination scanning through many expensively-annotated rows.

- Add plain_objects manager to ScriptVersion for use by API viewsets
- Update ScriptViewSet and TranslateScriptViewSet to use plain_objects with only the score annotation (needed for ordering)
- Fix ScriptSerializer score field: source='votes.count' was broken (votes is a relation on Script, not ScriptVersion); now correctly reads from the score annotation on the queryset