### PR TITLE
fix(filters): match multi-word character ids in include/exclude

### DIFF
--- a/scripts/filters.py
+++ b/scripts/filters.py
@@ -46,7 +46,7 @@ def exclude_characters(queryset, value):
 
 
 def name_to_id(name: str):
-    return name.replace(" ", "_").replace("'", "").lower()
+    return name.replace(" ", "").replace("'", "").lower()
 
 
 class BaseScriptVersionFilter(filters.FilterSet):

--- a/scripts/filters.py
+++ b/scripts/filters.py
@@ -32,7 +32,7 @@ def include_characters(queryset, value):
         character = script_json.strip_special_characters(character.strip())
         if character in ",;:/":
             continue
-        queryset = queryset.filter(content__contains=[{"id": name_to_id(character)}])
+        queryset = queryset.filter(content__contains=[{"id": script_json.name_to_id(character)}])
     return queryset
 
 
@@ -41,12 +41,8 @@ def exclude_characters(queryset, value):
         character = script_json.strip_special_characters(character.strip())
         if character in ",;:/":
             continue
-        queryset = queryset.exclude(content__contains=[{"id": name_to_id(character)}])
+        queryset = queryset.exclude(content__contains=[{"id": script_json.name_to_id(character)}])
     return queryset
-
-
-def name_to_id(name: str):
-    return name.replace(" ", "").replace("'", "").lower()
 
 
 class BaseScriptVersionFilter(filters.FilterSet):

--- a/scripts/script_json.py
+++ b/scripts/script_json.py
@@ -50,6 +50,10 @@ def strip_special_characters(character_id):
     return character_id.replace("_", "").replace("-", "").lower()
 
 
+def name_to_id(name):
+    return name.replace(" ", "").replace("'", "").lower()
+
+
 def strip_special_characters_from_json(json):
     new_json = []
     for item in json:

--- a/tests/test_name_to_id.py
+++ b/tests/test_name_to_id.py
@@ -1,0 +1,21 @@
+import pytest
+
+from scripts.script_json import name_to_id
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("Snake Charmer", "snakecharmer"),
+        ("Mutant", "mutant"),
+        ("Fortune Teller", "fortuneteller"),
+        ("Pit-Hag", "pit-hag"),
+        ("Lil' Monsta", "lilmonsta"),
+        ("snakecharmer", "snakecharmer"),
+        ("SNAKE CHARMER", "snakecharmer"),
+        ("  Snake  Charmer  ", "snakecharmer"),
+        ("", ""),
+    ],
+)
+def test_name_to_id(name, expected):
+    assert name_to_id(name) == expected


### PR DESCRIPTION
## Problem

The include/exclude character filters silently match nothing for any multi-word character.

Example: excluding `Snake Charmer` (URL `?exclude=Snake+Charmer`) still returns scripts containing the Snake Charmer.

## Cause

`name_to_id()` in `scripts/filters.py` replaced spaces with underscores:

```python
name.replace(" ", "_")  # "Snake Charmer" -> "snake_charmer"
```

But official character ids carry no separator (`snakecharmer`), so `content__contains=[{"id": "snake_charmer"}]` never matches. Single-word characters (e.g. `mutant`) worked only because they have no space.

## Fix

Strip the space instead of underscoring it, so `Snake Charmer` -> `snakecharmer`.

Verified against `dev/characters.json`: all 172 official character ids match `^[a-z0-9]+$` (no spaces, underscores, or hyphens), so removing spaces is safe and correct for both include and exclude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)